### PR TITLE
VolumesAndMountsPage: totals row text muting

### DIFF
--- a/frontend/pages/VolumesAndMountsPage.tsx
+++ b/frontend/pages/VolumesAndMountsPage.tsx
@@ -486,7 +486,7 @@ export default class VolumesAndMountsPage extends React.Component<
 							<td colSpan={99}>{loadingOrError}</td>
 						</tr>
 					) : null}
-					<tr>
+					<tr class="text-muted">
 						<td />
 						<td />
 						<td>{blobCount(totals)}</td>


### PR DESCRIPTION
this is because when looking at mobile, it was hard to see zoomed in that this was not an ordinary row (I was wondering which volume has like 60 TB of space...)